### PR TITLE
socketcandcl: enable out-of-source build

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -5,7 +5,7 @@
 sourcefiles = $(srcdir)/socketcand.c $(srcdir)/statistics.c $(srcdir)/beacon.c \
              $(srcdir)/state_bcm.c $(srcdir)/state_raw.c $(srcdir)/state_control.c
 executable = socketcand
-sourcefiles_cl = socketcandcl.c
+sourcefiles_cl = $(srcdir)/socketcandcl.c
 executable_cl = socketcandcl
 srcdir = @srcdir@
 prefix = @prefix@


### PR DESCRIPTION
Reference source file with $(srcdir).

Signed-off-by: Yegor Yefremov yegorslists@googlemail.com
