### PR TITLE
Remove inline keyword

### DIFF
--- a/socketcand.h
+++ b/socketcand.h
@@ -27,10 +27,10 @@
 
 #undef DEBUG_RECEPTION
 
-inline void state_bcm();
-inline void state_raw();
-inline void state_isotp();
-inline void state_control();
+void state_bcm();
+void state_raw();
+void state_isotp();
+void state_control();
 
 extern int client_socket;
 extern char **interface_names;

--- a/state_bcm.c
+++ b/state_bcm.c
@@ -28,7 +28,7 @@ int sc = -1;
 fd_set readfds;
 struct timeval tv;
 
-inline void state_bcm() {
+void state_bcm() {
 	int i, ret;
 	struct sockaddr_can caddr;
 	socklen_t caddrlen = sizeof(caddr);

--- a/state_control.c
+++ b/state_control.c
@@ -17,7 +17,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-inline void state_control() {
+void state_control() {
 	char buf[MAXLEN];
 	int i, items;
 

--- a/state_isotp.c
+++ b/state_isotp.c
@@ -24,7 +24,7 @@
 int si = -1;
 fd_set readfds;
 
-inline void state_isotp() {
+void state_isotp() {
 	int i, items, ret;
 
 	struct sockaddr_can addr;

--- a/state_raw.c
+++ b/state_raw.c
@@ -31,7 +31,7 @@ char ctrlmsg[CMSG_SPACE(sizeof(struct timeval)) + CMSG_SPACE(sizeof(__u32))];
 struct timeval tv;
 struct cmsghdr *cmsg;
 
-inline void state_raw() {
+void state_raw() {
 	char buf[MAXLEN];
 	int i, ret, items;
 


### PR DESCRIPTION
Fixes GCC5.x compilation issues related to C99 inline semantics.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>