### PR TITLE
Add SPDX identifiers

### DIFF
--- a/beacon.c
+++ b/beacon.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause) */
+
 #include "config.h"
 #include <stdio.h>
 #include <unistd.h>

--- a/beacon.h
+++ b/beacon.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause) */
+
 #define BROADCAST_PORT 42000
 #define BEACON_LENGTH 2048
 #define BEACON_TYPE "SocketCAN"

--- a/socketcand.c
+++ b/socketcand.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause) */
 /*
  * Authors:
  * Andre Naujoks (the socket server stuff)

--- a/socketcand.h
+++ b/socketcand.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause) */
+
 #include <pthread.h>
 #include <syslog.h>
 

--- a/socketcandcl.c
+++ b/socketcandcl.c
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause) */
 /*
  * Authors:
  * Andre Naujoks

--- a/state_bcm.c
+++ b/state_bcm.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause) */
+
 #include "config.h"
 #include "socketcand.h"
 #include "statistics.h"

--- a/state_control.c
+++ b/state_control.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause) */
+
 #include "config.h"
 #include "socketcand.h"
 #include "statistics.h"

--- a/state_isotp.c
+++ b/state_isotp.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause) */
+
 #include "config.h"
 #include "socketcand.h"
 

--- a/state_raw.c
+++ b/state_raw.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause) */
+
 #include "config.h"
 #include "socketcand.h"
 #include "statistics.h"

--- a/statistics.c
+++ b/statistics.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause) */
+
 #include "config.h"
 #include "statistics.h"
 #include <stdlib.h>

--- a/statistics.h
+++ b/statistics.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause) */
+
 #include <pthread.h>
 
 #define STAT_BUF_LEN 512


### PR DESCRIPTION
Software Package Data Exchange identifiers help to detect source file
licenses and hence simplify the FOSS compliance process.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>